### PR TITLE
Fix help usage like README

### DIFF
--- a/oj.py
+++ b/oj.py
@@ -861,7 +861,8 @@ class yukicoder(OnlineJudge):
 
 
 def main():
-    parser = OptionParser()
+    usage = "usage: %prog [options] ... [contest_id] problem_id"
+    parser = OptionParser(usage=usage)
     # function
     parser.add_option("-c", "--create-solution-template-file", action="store_true",
                       dest="create_solution_template_file", default=False,


### PR DESCRIPTION
コード内のヘルプメッセージに`... [contest_id] problem_id`の部分が無く、初めて利用する時に若干困ったのでREADMEと同じように修正しました。
