### PR TITLE
新しいAtcoderのジャッジシステムに対応

### DIFF
--- a/onlinejudge.py
+++ b/onlinejudge.py
@@ -584,15 +584,15 @@ class AtCoder(OnlineJudge):
         subprocess.call([setting['browser'], 'https://%s.contest.atcoder.jp/submissions/me' % self.contest_id])
 
     def get_language_id_from_extension(self):
-        return {'.cpp':'10',
-                '.cc':'10',
-                '.c':'1',
-                '.java':'3',
-                '.php':'5',
-                '.py':'7',
-                '.pl':'8',
-                '.rb':'9',
-                '.hs':'11'}
+        return {'.cpp':'4003',
+                '.cc':'4011',
+                '.c':'4001',
+                '.java':'4005',
+                '.php':'4044',
+                '.py':'4006',
+                '.pl':'4042',
+                '.rb':'4049',
+                '.hs':'4027'}
 
 
 class ZOJContest(OnlineJudge):

--- a/solution.py
+++ b/solution.py
@@ -36,7 +36,7 @@ class SolutionC(Solution):
     def __init__(self, source_file_name):
         Solution.__init__(self, source_file_name)
     def compile(self):
-        return subprocess.call(['gcc', '-O2', '-o', self.get_a_out_name(), '-Wno-deprecated', '-Wall', self.source_file_name]) == 0
+        return subprocess.call(['gcc', '-O2', '-o', self.get_a_out_name(), '-Wno-deprecated', '-Wall', '-std=gnu11', self.source_file_name]) == 0
     def get_execute_command_line(self):
         return ['./' + self.get_a_out_name()]
 
@@ -45,7 +45,7 @@ class SolutionCxx(Solution):
     def __init__(self, source_file_name):
         Solution.__init__(self, source_file_name)
     def compile(self):
-        return subprocess.call(['g++', '-O2', '-o', self.get_a_out_name(), '-Wno-deprecated', '-Wall', '-std=c++11', self.source_file_name]) == 0
+        return subprocess.call(['g++', '-O2', '-o', self.get_a_out_name(), '-Wno-deprecated', '-Wall', '-std=gnu++17', self.source_file_name]) == 0
     def get_execute_command_line(self):
         return ['./' + self.get_a_out_name()]
 
@@ -97,7 +97,7 @@ class SolutionPyPy(Solution):
         return True
     def get_execute_env(self):
         env=os.environ.copy()
-        env['PYENV_VERSION']='pypy-2.5.0'
+        env['PYENV_VERSION']='pypy-7.3.0'
         return env
     def get_execute_command_line(self):
         return ['pypy', self.source_file_name]
@@ -109,7 +109,7 @@ class SolutionPython3(Solution):
         return True
     def get_execute_env(self):
         env=os.environ.copy()
-        env['PYENV_VERSION']='3.4.2'
+        env['PYENV_VERSION']='3.8.2'
         return env
     def get_execute_command_line(self):
         return ['python3', self.source_file_name]
@@ -121,7 +121,7 @@ class SolutionPyPy3(Solution):
         return True
     def get_execute_env(self):
         env=os.environ.copy()
-        env['PYENV_VERSION']='pypy3-2.4.0'
+        env['PYENV_VERSION']='pypy3-7.3.0'
         return env
     def get_execute_command_line(self):
         return ['pypy3', self.source_file_name]
@@ -143,7 +143,7 @@ class SolutionRuby(Solution):
         return True
     def get_execute_env(self):
         env=os.environ.copy()
-        env['RBENV_VERSION']='2.2.0'
+        env['RBENV_VERSION']='2.7.1'
         return env
     def get_execute_command_line(self):
         return ['ruby', self.source_file_name]
@@ -185,7 +185,7 @@ class SolutionScala(Solution):
         Solution.__init__(self, source_file_name)
     def get_execute_env(self):
         env=os.environ.copy()
-        env['SCALAENV_VERSION']='scala-2.11.5'
+        env['SCALAENV_VERSION']='scala-2.13.1'
     def compile(self):
         return subprocess.call(['scalac', self.source_file_name],env=self.get_execute_env()) == 0
     def get_execute_command_line(self):


### PR DESCRIPTION
いつも便利に使わさせていただいております。

2020/04/12 の ABC162 より、[使用言語](https://abc162.contest.atcoder.jp/) が変更になりました。これにより、新しいコンパイラのバージョンが使用できるようになりました。

そのため、OnlineJudgeHelper でも提出時とローカルでの実行時に、新しいバージョンのものを使用したいです。

いきなりのパッチで恐れ入りますが、ご検討いただけると幸いです。

## 1. Problem_ID の変更

現在、たとえば、cpp だと `C++11 (GCC 4.8.1)` で提出されますが、 `C++ (GCC 9.2.1)` で提出したいです。そのため、problem_id の配列の内容を変更しました。

新しい Problem ID は[提出ページ](https://abc162.contest.atcoder.jp/submit) のソースに記述されているものを使用しています。

<img src=https://user-images.githubusercontent.com/8403570/79072574-b3f5ad00-7d1c-11ea-9450-0ce52e49fc71.png width="50%">

## 2. コンパイラオプションの変更

ローカルでテストを通す際に、ジャッジシステムと同じバージョンを使用するように変更しました。

新しいバージョンは、 [Language Test 202001](https://atcoder.jp/contests/language-test-202001) に記載のものを使用しています。

## 備考

Problem_ IDとコンパイラのバージョンについて、上記の方法で確認を行い変更しておりますが、挙動をこちらで確認できているのは C++ のみです（申し訳ありません）。