### PR TITLE
たまにログインできない問題への対症療法

### DIFF
--- a/onlinejudge.py
+++ b/onlinejudge.py
@@ -542,7 +542,7 @@ class AtCoder(OnlineJudge):
         # print(html)
         pattern = re.compile('<input type="hidden" name="csrf_token" value="(.+)" />')
         result = pattern.findall(html)
-        csrf_token = result[0]
+        csrf_token = result[0].replace('&#43;', '+')
 
         setting = json.load(open(self.options.setting_file_path))['atcoder']
         postdata = dict()
@@ -575,7 +575,7 @@ class AtCoder(OnlineJudge):
         html = self.download_html().decode('utf-8')
         pattern = re.compile('<input type="hidden" name="csrf_token" value="(.+)" />')
         result = pattern.findall(html)
-        csrf_token = result[0]
+        csrf_token = result[0].replace('&#43;', '+')
 
         postdata = dict()
         postdata['data.TaskScreenName'] = self.problem_id


### PR DESCRIPTION
Atcoder の新しいURL形式に対応していただきありがとうございます。（ちょうど[同じこと](https://github.com/kumamotone/OnlineJudgeHelper/commits/change_atcoder_login)をやっていたのですがmaster を pull してなかったので気づきませんでした…）

現状login時に403で失敗することがあるのですが、失敗することもあれば成功することもあり、失敗するときの csrf_token を見てみたところ、 csrf_token に `&#43;` が含まれている場合に失敗するようでした。

43は、[Unicodeで+相当](https://www.codetable.net/decimal/43)の文字らしく、もしやと思い`.replace('&#43;', '+')` をかけてみたところ、 `&#43;` が含まれている場合においても一応ログインできるようになりました。

これは正しい方法ではないと思うのですが、この状態で一応ログインに失敗することは（20回ほど試してみたところ）なくなったので、ご参考までにPRお送りします。（ご不要でしたらcloseしていただいて構いません）