### PR TITLE
AOJのダウンロードに失敗する問題を修正

### DIFF
--- a/onlinejudge.py
+++ b/onlinejudge.py
@@ -372,16 +372,18 @@ class AOJ(OnlineJudge):
         return 'http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=' + self.problem_id
 
     def download(self):
-        html = self.download_html()
-        index = html.rfind('>Sample Input</')
-        html = html[index:]
-        p = re.compile('<pre>(.+?)</pre>', re.M | re.S | re.I)
+        html = self.download_html().decode('utf-8')
+        if '入力例' in html:
+            html = html[html.find('入力例'):]
+        if 'Sample Input' in html:
+            html = html[html.find('Sample Input'):]
+        p = re.compile('<pre.*?>(.+?)</pre>', re.M | re.S | re.I)
         result = p.findall(html)
-        n = len(result) / 2;
+        n = len(result) // 2
         for index in range(n):
             input_file_name = self.get_input_file_path(index)
             output_file_name = self.get_output_file_path(index)
-            open(input_file_name, 'w').write(self.format_pre(result[index * 2]))
+            open(input_file_name, 'w').write(self.format_pre(result[index * 2 + 0]))
             open(output_file_name, 'w').write(self.format_pre(result[index * 2 + 1]))
         return True
 


### PR DESCRIPTION
## 概要

以下環境でAOJのテストケースをダウンロードするとエラーが出力されたため、
`AtCoder` の `download` メソッドを流用して修正しました。

## 環境

```
% python --version
Python 3.8.2
% sw_vers  
ProductName:    Mac OS X
ProductVersion: 10.15.6
BuildVersion:   19G2021
```

## エラー内容

当初のエラー

```
Traceback (most recent call last):
  File "***/OnlineJudgeHelper/oj.py", line 177, in <module>
    main()
  File "***/OnlineJudgeHelper/oj.py", line 172, in main
    online_judge.check()
  File "***/OnlineJudgeHelper/onlinejudge.py", line 154, in check
    self.download()
  File "***/OnlineJudgeHelper/onlinejudge.py", line 376, in download
    index = html.rfind('>Sample Input</')
TypeError: argument should be integer or bytes-like object, not 'str'
```

375行目に `.decode('UTF-8')` を追加後

```
Traceback (most recent call last):
  File "***/OnlineJudgeHelper/oj.py", line 177, in <module>
    main()
  File "***/OnlineJudgeHelper/oj.py", line 172, in main
    online_judge.check()
  File "***/OnlineJudgeHelper/onlinejudge.py", line 154, in check
    self.download()
  File "***/OnlineJudgeHelper/onlinejudge.py", line 381, in download
    for index in range(n):
TypeError: 'float' object cannot be interpreted as an integer
```

378行目を `n = len(result) // 2` に変更してエラーはなくなりましたがサンプルをダウンロードできないケースがあり、
`AtCoder` の `download` メソッドがそのまま使えることが分かったので差し替えました。

## ダウンロードが確認できたケース

- 従前のコードで利用できていたと思われるケース（`>Sample Input</`以下の`<pre>`）
http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=1000
- 【新規対応】サンプルの見出しが数字付きのケース
http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=ALDS1_1_A
- 【新規対応】`<pre class="format">` とpreにclass属性が付くケース
http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=ALDS1_1_C

## そのほか
副次的に、日本語版の見出し「入力例」にも対応するようになりましたが、
通常は英語版の画面でダウンロードされると思われるため確認していません。